### PR TITLE
fix substring issue in 'already installed'-classification

### DIFF
--- a/src/lucide_lustre/internal/install_single.gleam
+++ b/src/lucide_lustre/internal/install_single.gleam
@@ -41,7 +41,7 @@ import lustre/element/svg"
   }
 
   use <- bool.guard(
-    case string.contains(file, "pub fn " <> name) {
+    case string.contains(file, "pub fn " <> name <> "(") {
       True -> {
         io.println("Icon " <> icon_name <> " is already installed")
         True


### PR DESCRIPTION
Noticed that installing `message-circle` after  `message-circle-plus` doesn't work since it's a substring and the check determines "already installed".